### PR TITLE
Support temporary AWS credential (STS)

### DIFF
--- a/lib/logstash/plugin_mixins/aws_config.rb
+++ b/lib/logstash/plugin_mixins/aws_config.rb
@@ -13,7 +13,7 @@ module LogStash::PluginMixins::AwsConfig
   end
 
   US_EAST_1 = "us-east-1"
-  
+
   public
   def setup_aws_config
     # The AWS Region
@@ -21,25 +21,28 @@ module LogStash::PluginMixins::AwsConfig
                                   "eu-west-1", "ap-southeast-1", "ap-southeast-2",
                                   "ap-northeast-1", "sa-east-1", "us-gov-west-1"], :default => US_EAST_1
 
-    # This plugin uses the AWS SDK and supports several ways to get credentials, which will be tried in this order...   
-    # 1. Static configuration, using `access_key_id` and `secret_access_key` params in logstash plugin config   
-    # 2. External credentials file specified by `aws_credentials_file`   
-    # 3. Environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`   
-    # 4. Environment variables `AMAZON_ACCESS_KEY_ID` and `AMAZON_SECRET_ACCESS_KEY`   
-    # 5. IAM Instance Profile (available when running inside EC2)   
+    # This plugin uses the AWS SDK and supports several ways to get credentials, which will be tried in this order...
+    # 1. Static configuration, using `access_key_id` and `secret_access_key` params in logstash plugin config
+    # 2. External credentials file specified by `aws_credentials_file`
+    # 3. Environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
+    # 4. Environment variables `AMAZON_ACCESS_KEY_ID` and `AMAZON_SECRET_ACCESS_KEY`
+    # 5. IAM Instance Profile (available when running inside EC2)
     config :access_key_id, :validate => :string
 
     # The AWS Secret Access Key
     config :secret_access_key, :validate => :string
 
-    # Should we require (true) or disable (false) using SSL for communicating with the AWS API   
+    # The AWS Session token for temprory credential
+    config :session_token, :validate => :string
+
+    # Should we require (true) or disable (false) using SSL for communicating with the AWS API
     # The AWS SDK for Ruby defaults to SSL so we preserve that
     config :use_ssl, :validate => :boolean, :default => true
 
     # URI to proxy server if required
     config :proxy_uri, :validate => :string
 
-    # Path to YAML file containing a hash of AWS credentials.   
+    # Path to YAML file containing a hash of AWS credentials.
     # This file will only be loaded if `access_key_id` and
     # `secret_access_key` aren't set. The contents of the
     # file should look like this:
@@ -56,25 +59,19 @@ module LogStash::PluginMixins::AwsConfig
       @logger.warn("Likely config error: Only one of access_key_id or secret_access_key was provided but not both.")
     end
 
-    if ((!@access_key_id || !@secret_access_key)) && @aws_credentials_file
-      access_creds = YAML.load_file(@aws_credentials_file)
-
-      @access_key_id = access_creds[:access_key_id]
-      @secret_access_key = access_creds[:secret_access_key]
+    if @access_key_id && @secret_access_key
+      opts = {
+        :access_key_id => @access_key_id,
+        :secret_access_key => @secret_access_key
+      }
+      opts[:session_token] = @session_token if @session_token
+    elsif @aws_credentials_file
+      opts = YAML.load_file(@aws_credentials_file)
     end
 
-    opts = {}
-
-    if (@access_key_id && @secret_access_key)
-      opts[:access_key_id] = @access_key_id
-      opts[:secret_access_key] = @secret_access_key
-    end
-
+    opts[:proxy_uri] = @proxy_uri if @proxy_uri
     opts[:use_ssl] = @use_ssl
 
-    if (@proxy_uri)
-      opts[:proxy_uri] = @proxy_uri
-    end
 
     # The AWS SDK for Ruby doesn't know how to make an endpoint hostname from a region
     # for example us-west-1 -> foosvc.us-west-1.amazonaws.com
@@ -86,7 +83,7 @@ module LogStash::PluginMixins::AwsConfig
     # for example, CloudWatch, { :cloud_watch_endpoint => "monitoring.#{region}.amazonaws.com" }
     # For a list, see https://github.com/aws/aws-sdk-ruby/blob/master/lib/aws/core/configuration.rb
     opts.merge!(self.aws_service_endpoint(@region))
-    
+
     return opts
   end # def aws_options_hash
 

--- a/spec/fixtures/aws_temporary_credentials_file_sample_test.yml
+++ b/spec/fixtures/aws_temporary_credentials_file_sample_test.yml
@@ -1,0 +1,3 @@
+:access_key_id: '1234'
+:secret_access_key: secret
+:session_token: session_token

--- a/spec/plugin_mixin/aws_config_spec.rb
+++ b/spec/plugin_mixin/aws_config_spec.rb
@@ -14,25 +14,62 @@ class DummyInputAwsConfig < LogStash::Inputs::Base
 end
 
 describe LogStash::PluginMixins::AwsConfig do
-  it 'should support passing credentials as key, value' do
-    settings = { 'access_key_id' => '1234',  'secret_access_key' => 'secret' }
 
-    config = DummyInputAwsConfig.new(settings)
-    config.aws_options_hash[:access_key_id].should == settings['access_key_id']
-    config.aws_options_hash[:secret_access_key].should == settings['secret_access_key']
+  let(:settings) { {} }
+
+  subject { DummyInputAwsConfig.new(settings).aws_options_hash }
+
+  describe 'config credential' do
+
+    context 'in credential file' do
+      let(:settings) { { 'aws_credentials_file' => File.join(File.dirname(__FILE__), '..', 'fixtures/aws_credentials_file_sample_test.yml') } }
+
+      it 'should support reading configuration from a yaml file' do
+        subject[:access_key_id].should == '1234'
+        subject[:secret_access_key].should == 'secret'
+      end
+    end
+
+    context 'inline' do
+      context 'temporary credential' do
+        let(:settings) { { 'access_key_id' => '1234', 'secret_access_key' => 'secret', 'session_token' => 'session_token' } }
+
+        it "should support passing as key, value, and session_token" do
+          subject[:access_key_id].should == settings['access_key_id']
+          subject[:secret_access_key].should == settings['secret_access_key']
+          subject[:session_token].should == settings['session_token']
+        end
+      end
+
+      context 'normal credential' do
+        let(:settings) { { 'access_key_id' => '1234',  'secret_access_key' => 'secret' } }
+
+        it 'should support passing credentials as key, value' do
+          subject[:access_key_id].should == settings['access_key_id']
+          subject[:secret_access_key].should == settings['secret_access_key']
+        end
+      end
+    end
+
   end
 
-  it 'should support reading configuration from a yaml file' do
-    settings = { 'aws_credentials_file' => File.join(File.dirname(__FILE__), '..', 'fixtures/aws_credentials_file_sample_test.yml') }
-    config = DummyInputAwsConfig.new(settings)
-    config.aws_options_hash[:access_key_id].should == '1234'
-    config.aws_options_hash[:secret_access_key].should == 'secret'
-  end
+  describe 'config region' do
 
-  it 'should call the class to generate the endpoint configuration' do
-    settings = { 'access_key_id' => '1234',  'secret_access_key' => 'secret', 'region' => 'us-west-2' }
+    context 'region provided' do
+      let(:settings) { { 'access_key_id' => '1234',  'secret_access_key' => 'secret', 'region' => 'us-west-2' } }
 
-    config = DummyInputAwsConfig.new(settings)
-    config.aws_options_hash[:dummy_input_aws_config_region].should == "us-west-2.awswebservice.local"
+      it 'should use provided region to generate the endpoint configuration' do
+        subject[:dummy_input_aws_config_region].should == "us-west-2.awswebservice.local"
+      end
+    end
+
+    context "region not provided" do
+      let(:settings) { { 'access_key_id' => '1234',  'secret_access_key' => 'secret'} }
+
+      it 'should use default region to generate the endpoint configuration' do
+        subject[:dummy_input_aws_config_region].should == "us-east-1.awswebservice.local"
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Some times I need to supply a temporary AWS credentail to logstash plugins(e.g. SNS) for testing purpose. so I created this patch. Also I refactor the specs. 