### PR TITLE
use aws-sdk ruby v1 api

### DIFF
--- a/logstash-mixin-aws.gemspec
+++ b/logstash-mixin-aws.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-mixin-aws'
-  s.version         = '0.1.5'
+  s.version         = '0.1.6'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "AWS mixins to provide a unified interface for Amazon Webservice"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency 'logstash', '>= 1.4.0', '< 2.0.0'
   s.add_runtime_dependency 'logstash-codec-plain'
-  s.add_runtime_dependency 'aws-sdk'
+  s.add_runtime_dependency 'aws-sdk', '~> 1.61.0'
   s.add_development_dependency 'logstash-devutils'
 end
 


### PR DESCRIPTION
one of the breaking changes in the v1->v2 update is the new top level module is now named `Aws` instead of `AWS` and probably a lot more of surprises.