### PR TITLE
AWS-Region eu-central-1 added

### DIFF
--- a/lib/logstash/plugin_mixins/aws_config.rb
+++ b/lib/logstash/plugin_mixins/aws_config.rb
@@ -17,7 +17,7 @@ module LogStash::PluginMixins::AwsConfig
   public
   def setup_aws_config
     # The AWS Region
-    config :region, :validate => [US_EAST_1, "us-west-1", "us-west-2",
+    config :region, :validate => [US_EAST_1, "us-west-1", "us-west-2", "eu-central-1",
                                   "eu-west-1", "ap-southeast-1", "ap-southeast-2",
                                   "ap-northeast-1", "sa-east-1", "us-gov-west-1"], :default => US_EAST_1
 


### PR DESCRIPTION
In October 2014 Amazon launched a new AWS Region in Frankfurt, Germany.
Since the region string was missing in the aws_config.rb file it was
not possible to use this region together with the SQS-Logstash plugin.

This fix adds the new correct region string to the list of accepted
region strings in aws_config.rb