### PR TITLE
adding china-1 to the list of supported regions

### DIFF
--- a/lib/logstash/plugin_mixins/aws_config.rb
+++ b/lib/logstash/plugin_mixins/aws_config.rb
@@ -19,7 +19,8 @@ module LogStash::PluginMixins::AwsConfig
     # The AWS Region
     config :region, :validate => [US_EAST_1, "us-west-1", "us-west-2", "eu-central-1",
                                   "eu-west-1", "ap-southeast-1", "ap-southeast-2",
-                                  "ap-northeast-1", "sa-east-1", "us-gov-west-1"], :default => US_EAST_1
+                                  "ap-northeast-1", "sa-east-1", "us-gov-west-1",
+                                  "cn-north-1"], :default => US_EAST_1
 
     # This plugin uses the AWS SDK and supports several ways to get credentials, which will be tried in this order...
     # 1. Static configuration, using `access_key_id` and `secret_access_key` params in logstash plugin config

--- a/logstash-mixin-aws.gemspec
+++ b/logstash-mixin-aws.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-mixin-aws'
-  s.version         = '0.1.9'
+  s.version         = '0.1.10'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "AWS mixins to provide a unified interface for Amazon Webservice"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Adding the missing `cn-china-1` region http://docs.aws.amazon.com/general/latest/gr/isolated_regions.html fixes: #11 