### PR TITLE
declare a dependency on logstash-core snapshot

### DIFF
--- a/logstash-mixin-aws.gemspec
+++ b/logstash-mixin-aws.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.test_files = s.files.grep(%r{^(test|spec|features)/})
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core", ">= 2.0.0", "< 3.0.0"
+  s.add_runtime_dependency "logstash-core", "~> 2.0.0.snapshot"
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'aws-sdk-v1', '>= 1.61.0'
   s.add_runtime_dependency 'aws-sdk', '~> 2.1.0'


### PR DESCRIPTION
Make sure we use the snapshot dependency and not the official gem.
This change will make sure we pickup up newer releases of the snapshot.

```
~/e/l/t/logstash-mixin-aws git:master ❯❯❯ bundle install                                                                                                                                                                                                                                                                                                                ✱
Fetching gem metadata from https://rubygems.org/........
Fetching version metadata from https://rubygems.org/...
Fetching dependency metadata from https://rubygems.org/..
Resolving dependencies.....
Using rake 10.4.2
Installing jmespath 1.1.3
Installing aws-sdk-core 2.1.23
Installing aws-sdk-resources 2.1.23
Installing aws-sdk 2.1.23
Using json 1.8.3
Using nokogiri 1.6.6.2
Using aws-sdk-v1 1.66.0
Using cabin 0.7.1
Using clamp 0.6.5
Using coderay 1.1.0
Using concurrent-ruby 0.9.1
Using diff-lcs 1.2.5
Using ffi 1.9.10
Using filesize 0.0.4
Using gem_publisher 1.5.0
Using gems 0.8.3
Using i18n 0.6.9
Using insist 1.0.0
Using jrjackson 0.2.9
Using kramdown 1.8.0
Using minitar 0.5.4
Using method_source 0.8.2
Using slop 3.6.0
Using spoon 0.0.4
Using pry 0.10.1
Using stud 0.0.22
Using thread_safe 0.3.5
Using polyglot 0.3.5
Using treetop 1.4.15
Using logstash-core 2.0.0.snapshot2
Using logstash-codec-plain 1.0.0
Using rspec-support 3.1.2
Using rspec-core 3.1.7
Using rspec-expectations 3.1.2
Using rspec-mocks 3.1.3
Using rspec 3.1.0
Using rspec-wait 0.0.7
Using logstash-devutils 0.0.16
Using logstash-mixin-aws 2.0.0 from source at .
Using bundler 1.10.6
Bundle complete! 2 Gemfile dependencies, 41 gems now installed.
Use `bundle show [gemname]` to see where a bundled gem is installed.
```