### PR TITLE
"credentials" method name conflicts with the config setting of the same name.

### DIFF
--- a/lib/logstash/plugin_mixins/aws_config/v2.rb
+++ b/lib/logstash/plugin_mixins/aws_config/v2.rb
@@ -15,7 +15,7 @@ module LogStash::PluginMixins::AwsConfig::V2
       @logger.warn("Likely config error: Only one of access_key_id or secret_access_key was provided but not both.")
     end
 
-    opts[:credentials] = credentials if credentials
+    opts[:credentials] = credentials_v2 if credentials_v2
 
     opts[:http_proxy] = @proxy_uri if @proxy_uri
 
@@ -38,7 +38,7 @@ module LogStash::PluginMixins::AwsConfig::V2
   end
 
   private
-  def credentials
+  def credentials_v2
     @creds ||= begin
                  if @access_key_id && @secret_access_key
                    credentials_opts = {


### PR DESCRIPTION
I'm trying to fix the tests so the s3 input plugin using the aws-sdk-v2 pull request code and discovered that this is the probable issue.   

The current rspec tests pass with this change, and testing on a rebased version of the above logstash-input-s3 code gives the following changes (which I believe are what we'd expect..)

  1) LogStash::Inputs::S3#get_s3object with deprecated credentials option should instantiate AWS::S3 clients with a proxy set
     Failure/Error: subject.send(:get_s3object)
       <#<Module:0x48e07006>::Resource (class)> received :new with unexpected arguments
         expected: ({:access_key_id=>"1234", :secret_access_key=>"secret", :http_proxy=>"http://example.com", :region=>"us-east-1"})
              got: ({:credentials=>#<Aws::Credentials access_key_id="1234">, :http_proxy=>"http://example.com", :region=>"us-east-1"})
     # ./lib/logstash/inputs/s3.rb:388:in `get_s3object'
     # ./spec/inputs/s3_spec.rb:78:in `block in (root)'

  2) LogStash::Inputs::S3#get_s3object with modern access key options should instantiate AWS::S3 clients with a proxy set
     Failure/Error: subject.send(:get_s3object)
       <#<Module:0x48e07006>::Resource (class)> received :new with unexpected arguments
         expected: ({:access_key_id=>"1234", :secret_access_key=>"secret", :http_proxy=>"http://example.com", :region=>"us-east-1"})
              got: ({:credentials=>#<Aws::Credentials access_key_id="1234">, :http_proxy=>"http://example.com", :region=>"us-east-1"})
     # ./lib/logstash/inputs/s3.rb:388:in `get_s3object'
     # ./spec/inputs/s3_spec.rb:100:in `block in (root)'
