### PR TITLE
Allow user to provide a role to assume

### DIFF
--- a/lib/logstash/plugin_mixins/aws_config/generic.rb
+++ b/lib/logstash/plugin_mixins/aws_config/generic.rb
@@ -10,7 +10,7 @@ module LogStash::PluginMixins::AwsConfig::Generic
 
     # This plugin uses the AWS SDK and supports several ways to get credentials, which will be tried in this order:
     #
-    # 1. Static configuration, using `access_key_id` and `secret_access_key` params in logstash plugin config
+    # 1. Static configuration, using `access_key_id` and `secret_access_key` params or `role_arn` in the logstash plugin config
     # 2. External credentials file specified by `aws_credentials_file`
     # 3. Environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
     # 4. Environment variables `AMAZON_ACCESS_KEY_ID` and `AMAZON_SECRET_ACCESS_KEY`
@@ -26,10 +26,12 @@ module LogStash::PluginMixins::AwsConfig::Generic
     # URI to proxy server if required
     config :proxy_uri, :validate => :string
 
-    # Role to assume
+    # The AWS IAM Role to assume, if any.
+    # This is used to generate temporary credentials typically for cross-account access.
+    # See https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html for more information.
     config :role_arn, :validate => :string
 
-    # Session name to use when assuming a role
+    # Session name to use when assuming an IAM role
     config :role_session_name, :validate => :string, :default => "logstash"
 
     # Path to YAML file containing a hash of AWS credentials.

--- a/lib/logstash/plugin_mixins/aws_config/generic.rb
+++ b/lib/logstash/plugin_mixins/aws_config/generic.rb
@@ -30,7 +30,7 @@ module LogStash::PluginMixins::AwsConfig::Generic
     config :role_arn, :validate => :string
 
     # Session name to use when assuming a role
-    config :role_session_name, :validate => :string, :default => "logstash-s3-plugin"
+    config :role_session_name, :validate => :string, :default => "logstash"
 
     # Path to YAML file containing a hash of AWS credentials.
     # This file will only be loaded if `access_key_id` and

--- a/lib/logstash/plugin_mixins/aws_config/generic.rb
+++ b/lib/logstash/plugin_mixins/aws_config/generic.rb
@@ -26,6 +26,12 @@ module LogStash::PluginMixins::AwsConfig::Generic
     # URI to proxy server if required
     config :proxy_uri, :validate => :string
 
+    # Role to assume
+    config :role_arn, :validate => :string
+
+    # Session name to use when assuming a role
+    config :role_session_name, :validate => :string, :default => "logstash-s3-plugin"
+
     # Path to YAML file containing a hash of AWS credentials.
     # This file will only be loaded if `access_key_id` and
     # `secret_access_key` aren't set. The contents of the

--- a/lib/logstash/plugin_mixins/aws_config/v1.rb
+++ b/lib/logstash/plugin_mixins/aws_config/v1.rb
@@ -22,6 +22,10 @@ module LogStash::PluginMixins::AwsConfig::V1
   def aws_options_hash
     opts = {}
 
+    if @role_arn || @role_session_name
+      @logger.warn("role_arn and role_session_name settings are not supported in the v1 plugin")
+    end
+
     if @access_key_id.is_a?(NilClass) ^ @secret_access_key.is_a?(NilClass)
       @logger.warn("Likely config error: Only one of access_key_id or secret_access_key was provided but not both.")
     end

--- a/lib/logstash/plugin_mixins/aws_config/v2.rb
+++ b/lib/logstash/plugin_mixins/aws_config/v2.rb
@@ -47,21 +47,25 @@ module LogStash::PluginMixins::AwsConfig::V2
                    }
 
                    credentials_opts[:session_token] = @session_token if @session_token
-                 elsif @aws_credentials_file
-                   credentials_opts = YAML.load_file(@aws_credentials_file)
-                 elsif @role_arn
-                   credentials_opts = assume_role.credentials
-                 end
-
-                 if credentials_opts
                    Aws::Credentials.new(credentials_opts[:access_key_id],
                                         credentials_opts[:secret_access_key],
                                         credentials_opts[:session_token])
+                 elsif @aws_credentials_file
+                   credentials_opts = YAML.load_file(@aws_credentials_file)
+                   Aws::Credentials.new(credentials_opts[:access_key_id],
+                                        credentials_opts[:secret_access_key],
+                                        credentials_opts[:session_token])
+                 elsif @role_arn
+                   assume_role
                  end
                end
   end
 
   def assume_role
-    Aws::STS::Client.new(region: @region).assume_role(role_arn: @role_arn, role_session_name: @role_session_name)
+    Aws::AssumeRoleCredentials.new(
+      client: Aws::STS::Client.new(region: @region),
+      role_arn: @role_arn,
+      role_session_name: @role_session_name
+    )
   end
 end

--- a/lib/logstash/plugin_mixins/aws_config/v2.rb
+++ b/lib/logstash/plugin_mixins/aws_config/v2.rb
@@ -49,6 +49,8 @@ module LogStash::PluginMixins::AwsConfig::V2
                    credentials_opts[:session_token] = @session_token if @session_token
                  elsif @aws_credentials_file
                    credentials_opts = YAML.load_file(@aws_credentials_file)
+                 elsif @role_arn
+                   credentials_opts = assume_role.credentials
                  end
 
                  if credentials_opts
@@ -57,5 +59,9 @@ module LogStash::PluginMixins::AwsConfig::V2
                                         credentials_opts[:session_token])
                  end
                end
+  end
+
+  def assume_role
+    Aws::STS::Client.new(region: @region).assume_role(role_arn: @role_arn, role_session_name: @role_session_name})
   end
 end

--- a/lib/logstash/plugin_mixins/aws_config/v2.rb
+++ b/lib/logstash/plugin_mixins/aws_config/v2.rb
@@ -62,6 +62,6 @@ module LogStash::PluginMixins::AwsConfig::V2
   end
 
   def assume_role
-    Aws::STS::Client.new(region: @region).assume_role(role_arn: @role_arn, role_session_name: @role_session_name})
+    Aws::STS::Client.new(region: @region).assume_role(role_arn: @role_arn, role_session_name: @role_session_name)
   end
 end

--- a/logstash-mixin-aws.gemspec
+++ b/logstash-mixin-aws.gemspec
@@ -21,5 +21,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'aws-sdk-v1', '>= 1.61.0'
   s.add_runtime_dependency 'aws-sdk', '~> 2.3.0'
   s.add_development_dependency 'logstash-devutils'
+  s.add_development_dependency 'timecop'
 end
 

--- a/spec/plugin_mixin/aws_config_spec.rb
+++ b/spec/plugin_mixin/aws_config_spec.rb
@@ -2,6 +2,7 @@
 require "logstash/devutils/rspec/spec_helper"
 require "logstash/plugin_mixins/aws_config"
 require 'aws-sdk'
+require 'timecop'
 
 class DummyInputAwsConfigV2 < LogStash::Inputs::Base
   include LogStash::PluginMixins::AwsConfig::V2
@@ -122,6 +123,60 @@ describe LogStash::PluginMixins::AwsConfig::V2 do
           expect(subject.secret_access_key).to eq(settings['secret_access_key'])
         end
       end
+
+      context 'role arn is provided' do
+        let(:settings) { { 'role_arn' => 'arn:aws:iam::012345678910:role/foo', 'region' => 'us-west-2' } }
+        let(:sts_double) { instance_double(Aws::STS::Client) }
+        let(:now) { Time.now }
+        let(:expiration) { Time.at(now.to_i + 3600) }
+        let(:temp_credentials) {
+          double(credentials:
+                  double(
+                    access_key_id: '1234',
+                    secret_access_key: 'secret',
+                    session_token: 'session_token',
+                    expiration: expiration.to_s,
+                  )
+                )
+        }
+        let(:new_temp_credentials) {
+          double(credentials:
+                  double(
+                    access_key_id: '5678',
+                    secret_access_key: 'secret1',
+                    session_token: 'session_token1',
+                    expiration: expiration.to_s,
+                  )
+                )
+        }
+
+        before do
+          allow(Aws::STS::Client).to receive(:new).and_return(sts_double)
+          allow(sts_double).to receive(:assume_role)  {
+            if Time.now < expiration
+              temp_credentials
+            else
+              new_temp_credentials
+            end
+          }
+        end
+
+        it 'supports passing role_arn' do
+          Timecop.freeze(now) do
+            expect(subject.credentials.access_key_id).to eq('1234')
+            expect(subject.credentials.secret_access_key).to eq('secret')
+            expect(subject.credentials.session_token).to eq('session_token')
+          end
+        end
+
+        it 'rotates the keys once they expire' do
+          Timecop.freeze(Time.at(expiration.to_i + 100)) do
+            expect(subject.credentials.access_key_id).to eq('5678')
+            expect(subject.credentials.secret_access_key).to eq('secret1')
+            expect(subject.credentials.session_token).to eq('session_token1')
+          end
+        end       
+      end
     end
   end
 
@@ -184,4 +239,5 @@ describe LogStash::PluginMixins::AwsConfig::V2 do
       expect(subject).to eq({ :dummy_input_aws_config_region => "us-east-1.awswebservice.local" })  
     end
   end
+
 end


### PR DESCRIPTION
It's a common use case to read ELB logs. But if those ELB logs are written to an s3 bucket in a different account to where Logstash is running, it's impossible to give the third account permission to read them, because ELB logs are not owned by the account they exist in.

This change allows you to specify a role ARN that can be assumed in order to access resources.
