### PR TITLE
Add endpoint to config.

### DIFF
--- a/lib/logstash/plugin_mixins/aws_config/generic.rb
+++ b/lib/logstash/plugin_mixins/aws_config/generic.rb
@@ -26,6 +26,9 @@ module LogStash::PluginMixins::AwsConfig::Generic
     # URI to proxy server if required
     config :proxy_uri, :validate => :string
 
+    # Custom endpoint to connect to s3
+    config :endpoint, :validate => :string
+
     # Path to YAML file containing a hash of AWS credentials.
     # This file will only be loaded if `access_key_id` and
     # `secret_access_key` aren't set. The contents of the

--- a/lib/logstash/plugin_mixins/aws_config/v1.rb
+++ b/lib/logstash/plugin_mixins/aws_config/v1.rb
@@ -51,6 +51,10 @@ module LogStash::PluginMixins::AwsConfig::V1
     # For a list, see https://github.com/aws/aws-sdk-ruby/blob/master/lib/aws/core/configuration.rb
     opts.merge!(self.aws_service_endpoint(@region))
 
+    if !@endpoint.is_a?(NilClass)
+      opts[:endpoint] = @endpoint
+    end
+
     return opts
   end # def aws_options_hash
 end

--- a/lib/logstash/plugin_mixins/aws_config/v2.rb
+++ b/lib/logstash/plugin_mixins/aws_config/v2.rb
@@ -34,6 +34,10 @@ module LogStash::PluginMixins::AwsConfig::V2
       opts.merge!({ :region => @region })
     end
 
+    if !@endpoint.is_a?(NilClass)
+      opts[:endpoint] = @endpoint
+    end
+
     return opts
   end
 

--- a/spec/plugin_mixin/aws_config_spec.rb
+++ b/spec/plugin_mixin/aws_config_spec.rb
@@ -81,6 +81,16 @@ describe LogStash::PluginMixins::AwsConfig do
     end
   end
 
+  describe 'config endpoint' do
+    context "endpoint provided" do
+      let(:settings) { { 'access_key_id' => '1234',  'secret_access_key' => 'secret', 'endpoint' => 'http://localhost'} }
+
+      it 'should use specified endpoint' do
+          expect(subject[:endpoint]).to eq("http://localhost")
+      end
+    end
+  end
+
   context 'when we arent providing credentials' do
     let(:settings) { {} }
     it 'should always return a hash' do


### PR DESCRIPTION
Allow to specify the endpoint, to use with minio or other s3 compatible endpoints.