### PR TITLE
drop strict value validation for region option

### DIFF
--- a/lib/logstash/plugin_mixins/aws_config.rb
+++ b/lib/logstash/plugin_mixins/aws_config.rb
@@ -9,11 +9,6 @@ module LogStash::PluginMixins::AwsConfig
   require "logstash/plugin_mixins/aws_config/v2"
 
   US_EAST_1 = "us-east-1"
-  REGIONS_ENDPOINT = [US_EAST_1, "us-east-2", "us-west-1", "us-west-2",
-                      "eu-central-1", "eu-west-1", "eu-west-2",
-                      "ap-southeast-1", "ap-southeast-2", "ap-northeast-1",
-                      "ap-northeast-2", "sa-east-1", "us-gov-west-1",
-                      "cn-north-1", "ap-south-1", "ca-central-1"]
 
   def self.included(base)
     # Add these methods to the 'base' given.

--- a/lib/logstash/plugin_mixins/aws_config/generic.rb
+++ b/lib/logstash/plugin_mixins/aws_config/generic.rb
@@ -6,7 +6,7 @@ module LogStash::PluginMixins::AwsConfig::Generic
 
   def generic_aws_config
     # The AWS Region
-    config :region, :validate => LogStash::PluginMixins::AwsConfig::REGIONS_ENDPOINT, :default => LogStash::PluginMixins::AwsConfig::US_EAST_1 
+    config :region, :validate => :string, :default => LogStash::PluginMixins::AwsConfig::US_EAST_1
 
     # This plugin uses the AWS SDK and supports several ways to get credentials, which will be tried in this order:
     #


### PR DESCRIPTION
This looses the validation of the region option, removing the need to constantly add new regions as they are created.

fixes #30 