### PR TITLE
Updating aws-sdk to ~>3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.4.0
+  - Update aws-sdk to ~>3
+  
 ## 4.3.0
   - Drop strict value validation for region option #36
   - Add endpoint option to customize the endpoint uri #32

--- a/logstash-mixin-aws.gemspec
+++ b/logstash-mixin-aws.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-mixin-aws'
-  s.version         = '4.3.0'
+  s.version         = '4.4.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "AWS mixins to provide a unified interface for Amazon Webservice"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'aws-sdk-v1', '>= 1.61.0'
-  s.add_runtime_dependency 'aws-sdk', '~> 2'
+  s.add_runtime_dependency 'aws-sdk', '~> 3'
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'timecop'
 end


### PR DESCRIPTION
I have tested this change with the following plugins (and saw no failing tests): 

logstash-input-s3
logstash-output-s3
logstash-input-cloudwatch
logstash-output-cloudwatch
logstash-input-sqs
logstash-output-sqs
logstash-output-sns

Because there were no breaking changes, a minor version bump seems sufficient.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
