### PR TITLE
add optional external_id setting

### DIFF
--- a/lib/logstash/plugin_mixins/aws_config/generic.rb
+++ b/lib/logstash/plugin_mixins/aws_config/generic.rb
@@ -49,5 +49,7 @@ module LogStash::PluginMixins::AwsConfig::Generic
     # ----------------------------------
     #
     config :aws_credentials_file, :validate => :string
+    # A unique identifier that might be required when you assume a role in another account.
+    config :external_id, :validate => :string
   end
 end

--- a/lib/logstash/plugin_mixins/aws_config/v2.rb
+++ b/lib/logstash/plugin_mixins/aws_config/v2.rb
@@ -59,6 +59,8 @@ module LogStash::PluginMixins::AwsConfig::V2
                    Aws::Credentials.new(credentials_opts[:access_key_id],
                                         credentials_opts[:secret_access_key],
                                         credentials_opts[:session_token])
+                 elsif @role_arn && @external_id
+                   assume_role_with_external_id
                  elsif @role_arn
                    assume_role
                  end
@@ -70,6 +72,15 @@ module LogStash::PluginMixins::AwsConfig::V2
       :client => Aws::STS::Client.new(:region => @region),
       :role_arn => @role_arn,
       :role_session_name => @role_session_name
+    )
+  end
+
+  def assume_role_with_external_id
+    Aws::AssumeRoleCredentials.new(
+      :client => Aws::STS::Client.new(:region => @region),
+      :role_arn => @role_arn,
+      :role_session_name => @role_session_name,
+      :external_id => @external_id
     )
   end
 end


### PR DESCRIPTION
Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/

Adds external_id option according to AWS [Documentation](https://docs.aws.amazon.com/cli/latest/reference/sts/assume-role.html)
