### PR TITLE
Fix: credentials/proxy with assumed role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.4.0
+  -  Fix: credentials/proxy with assumed role [#48](https://github.com/logstash-plugins/logstash-mixin-aws/pull/48).
+     Plugin no longer assumes `access_key_id`/`secret_access_key` credentials not to be set when `role_arn` specified.
+
 ## 4.3.0
   - Drop strict value validation for region option #36
   - Add endpoint option to customize the endpoint uri #32

--- a/lib/logstash/plugin_mixins/aws_config/generic.rb
+++ b/lib/logstash/plugin_mixins/aws_config/generic.rb
@@ -10,7 +10,7 @@ module LogStash::PluginMixins::AwsConfig::Generic
 
     # This plugin uses the AWS SDK and supports several ways to get credentials, which will be tried in this order:
     #
-    # 1. Static configuration, using `access_key_id` and `secret_access_key` params or `role_arn` in the logstash plugin config
+    # 1. Static configuration, using `access_key_id` and `secret_access_key` params in the logstash plugin config
     # 2. External credentials file specified by `aws_credentials_file`
     # 3. Environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
     # 4. Environment variables `AMAZON_ACCESS_KEY_ID` and `AMAZON_SECRET_ACCESS_KEY`
@@ -32,6 +32,7 @@ module LogStash::PluginMixins::AwsConfig::Generic
     # The AWS IAM Role to assume, if any.
     # This is used to generate temporary credentials typically for cross-account access.
     # See https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html for more information.
+    # When `role_arn` is set, AWS (`access_key_id`/`secret_access_key`) credentials still get used if they're configured.
     config :role_arn, :validate => :string
 
     # Session name to use when assuming an IAM role

--- a/lib/logstash/plugin_mixins/aws_config/v2.rb
+++ b/lib/logstash/plugin_mixins/aws_config/v2.rb
@@ -11,12 +11,6 @@ module LogStash::PluginMixins::AwsConfig::V2
   def aws_options_hash
     opts = {}
 
-    if @access_key_id.is_a?(NilClass) ^ @secret_access_key.is_a?(NilClass)
-      @logger.warn("Likely config error: Only one of access_key_id or secret_access_key was provided but not both.")
-    end
-
-    opts[:credentials] = credentials if credentials
-
     opts[:http_proxy] = @proxy_uri if @proxy_uri
 
     if self.respond_to?(:aws_service_endpoint)
@@ -27,42 +21,58 @@ module LogStash::PluginMixins::AwsConfig::V2
       opts[:region] = @region
     end
 
-    if !@endpoint.is_a?(NilClass)
-      opts[:endpoint] = @endpoint
+    opts[:endpoint] = @endpoint unless @endpoint.nil?
+
+    if @access_key_id.is_a?(NilClass) ^ @secret_access_key.is_a?(NilClass)
+      @logger.warn("Likely config error: Only one of access_key_id or secret_access_key was provided but not both.")
+    end
+
+    if @role_arn
+      credentials = assume_role(opts)
+      opts = { :credentials => credentials }
+    else
+      credentials = aws_credentials
+      opts[:credentials] = credentials if credentials
     end
 
     return opts
   end
 
   private
-  def credentials
-    @creds ||= begin
-                 if @access_key_id && @secret_access_key
-                   credentials_opts = {
-                     :access_key_id => @access_key_id,
-                     :secret_access_key => @secret_access_key.value
-                   }
 
-                   credentials_opts[:session_token] = @session_token.value if @session_token
-                   Aws::Credentials.new(credentials_opts[:access_key_id],
-                                        credentials_opts[:secret_access_key],
-                                        credentials_opts[:session_token])
-                 elsif @aws_credentials_file
-                   credentials_opts = YAML.load_file(@aws_credentials_file)
-                   Aws::Credentials.new(credentials_opts[:access_key_id],
-                                        credentials_opts[:secret_access_key],
-                                        credentials_opts[:session_token])
-                 elsif @role_arn
-                   assume_role
-                 end
-               end
+  def aws_credentials
+    if @access_key_id && @secret_access_key
+      credentials_opts = {
+        :access_key_id => @access_key_id,
+        :secret_access_key => @secret_access_key.value
+      }
+
+      credentials_opts[:session_token] = @session_token.value if @session_token
+      Aws::Credentials.new(credentials_opts[:access_key_id],
+                           credentials_opts[:secret_access_key],
+                           credentials_opts[:session_token])
+    elsif @aws_credentials_file
+      credentials_opts = YAML.load_file(@aws_credentials_file)
+      credentials_opts.default_proc = lambda { |hash, key| hash.fetch(key.to_s, nil) }
+      Aws::Credentials.new(credentials_opts[:access_key_id],
+                           credentials_opts[:secret_access_key],
+                           credentials_opts[:session_token])
+    else
+      nil # AWS client will read ENV or ~/.aws/credentials
+    end
   end
+  alias credentials aws_credentials
 
-  def assume_role
+  def assume_role(opts = {})
+    unless opts.key?(:credentials)
+      credentials = aws_credentials
+      opts[:credentials] = credentials if credentials
+    end
+
     Aws::AssumeRoleCredentials.new(
-      :client => Aws::STS::Client.new(:region => @region),
-      :role_arn => @role_arn,
-      :role_session_name => @role_session_name
+        :client => Aws::STS::Client.new(opts),
+        :role_arn => @role_arn,
+        :role_session_name => @role_session_name
     )
   end
 end

--- a/logstash-mixin-aws.gemspec
+++ b/logstash-mixin-aws.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-mixin-aws'
-  s.version         = '4.3.0'
+  s.version         = '4.4.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "AWS mixins to provide a unified interface for Amazon Webservice"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/plugin_mixin/aws_config_spec.rb
+++ b/spec/plugin_mixin/aws_config_spec.rb
@@ -206,13 +206,14 @@ describe LogStash::PluginMixins::AwsConfig::V2 do
           }
         end
 
-        let(:subject) { DummyInputAwsConfigV2NoRegionMethod.new(settings).aws_options_hash[:credentials] }
+        let(:aws_options_hash) { DummyInputAwsConfigV2NoRegionMethod.new(settings).aws_options_hash }
 
         before do
           allow_any_instance_of(Aws::AssumeRoleCredentials).to receive(:refresh) # called from #initialize
         end
 
         it 'uses credentials' do
+          subject = aws_options_hash[:credentials]
           expect( subject ).to be_a Aws::AssumeRoleCredentials
           expect( subject.client ).to be_a Aws::STS::Client
           expect( credentials = subject.client.config.credentials ).to be_a Aws::Credentials
@@ -220,8 +221,14 @@ describe LogStash::PluginMixins::AwsConfig::V2 do
         end
 
         it 'sets up proxy on client and region' do
+          subject = aws_options_hash[:credentials]
           expect( subject.client.config.http_proxy ).to eql 'http://a-proxy.net:1234'
-          expect( subject.client.config.region ).to eql 'us-west-2'
+          expect( subject.client.config.region ).to eql 'us-west-2' # probably redundant (kept for backwards compat)
+        end
+
+        it 'sets up region top-level' do
+          # NOTE: this one is required for real with role_arn :
+          expect( aws_options_hash[:region] ).to eql 'us-west-2'
         end
 
       end


### PR DESCRIPTION
When `role_arn` was set credentials where being ignored, same for the `proxy_uri` setting.

Various setups where tested with the S3 input.

Fixes https://github.com/logstash-plugins/logstash-mixin-aws/issues/40
Fixes https://github.com/logstash-plugins/logstash-mixin-aws/issues/44
Fixes https://github.com/logstash-plugins/logstash-input-sqs/issues/53
Closes https://github.com/logstash-plugins/logstash-mixin-aws/pull/41 (PR)
