### PR TITLE
Fix: proxy with assumed role (properly)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.4.1
+  -  Fix: proxy with assumed role (properly) [#50](https://github.com/logstash-plugins/logstash-mixin-aws/pull/50).
+
 ## 4.4.0
   -  Fix: credentials/proxy with assumed role [#48](https://github.com/logstash-plugins/logstash-mixin-aws/pull/48).
      Plugin no longer assumes `access_key_id`/`secret_access_key` credentials not to be set when `role_arn` specified.

--- a/lib/logstash/plugin_mixins/aws_config/v2.rb
+++ b/lib/logstash/plugin_mixins/aws_config/v2.rb
@@ -14,8 +14,8 @@ module LogStash::PluginMixins::AwsConfig::V2
     opts[:http_proxy] = @proxy_uri if @proxy_uri
 
     if @role_arn
-      credentials = assume_role(opts)
-      opts = { :credentials => credentials }
+      credentials = assume_role(opts.dup)
+      opts[:credentials] = credentials
     else
       credentials = aws_credentials
       opts[:credentials] = credentials if credentials

--- a/logstash-mixin-aws.gemspec
+++ b/logstash-mixin-aws.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-mixin-aws'
-  s.version         = '4.4.0'
+  s.version         = '4.4.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "AWS mixins to provide a unified interface for Amazon Webservice"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/plugin_mixin/aws_config_spec.rb
+++ b/spec/plugin_mixin/aws_config_spec.rb
@@ -226,6 +226,10 @@ describe LogStash::PluginMixins::AwsConfig::V2 do
           expect( subject.client.config.region ).to eql 'us-west-2' # probably redundant (kept for backwards compat)
         end
 
+        it 'sets up proxy top level' do # setting in on the client isn't enough!
+          expect( aws_options_hash[:http_proxy] ).to eql 'http://a-proxy.net:1234'
+        end
+
         it 'sets up region top-level' do
           # NOTE: this one is required for real with role_arn :
           expect( aws_options_hash[:region] ).to eql 'us-west-2'


### PR DESCRIPTION
this is a follow-up on #48 to fix #49 

the AWS setup actually requires us to (double) set the proxy on the main resource despite using the STS client.
previously, (when `role_arn =>` was present) we only set `http_proxy` on the [client](https://github.com/logstash-plugins/logstash-mixin-aws/blob/v4.4.0/lib/logstash/plugin_mixins/aws_config/v2.rb#L68), now it will be also present for the top-level AWS object using the config hash.
