### PR TITLE
Moved symbolization code shared by S3 input and SQS input plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.1.0
+  - Add support for 'addition_settings' configuration options used by S3 and SQS input plugins [#53](https://github.com/logstash-plugins/logstash-mixin-aws/pull/53).
+
 ## 5.0.0
   - Drop support for aws-sdk-v1
 

--- a/lib/logstash/plugin_mixins/aws_config/v2.rb
+++ b/lib/logstash/plugin_mixins/aws_config/v2.rb
@@ -31,11 +31,11 @@ module LogStash::PluginMixins::AwsConfig::V2
 
     opts[:endpoint] = @endpoint unless @endpoint.nil?
 
-    return opts
-  end
+    if respond_to?(:additional_settings)
+      opts.merge! symbolize_keys_and_cast_true_false(additional_settings)
+    end
 
-  def symbolized_settings
-    @symbolized_settings ||= symbolize_keys_and_cast_true_false(@additional_settings)
+    return opts
   end
 
   private

--- a/lib/logstash/plugin_mixins/aws_config/v2.rb
+++ b/lib/logstash/plugin_mixins/aws_config/v2.rb
@@ -32,7 +32,7 @@ module LogStash::PluginMixins::AwsConfig::V2
     opts[:endpoint] = @endpoint unless @endpoint.nil?
 
     if respond_to?(:additional_settings)
-      opts.merge! symbolize_keys_and_cast_true_false(additional_settings)
+      opts = symbolize_keys_and_cast_true_false(additional_settings).merge(opts)
     end
 
     return opts

--- a/lib/logstash/plugin_mixins/aws_config/v2.rb
+++ b/lib/logstash/plugin_mixins/aws_config/v2.rb
@@ -34,6 +34,10 @@ module LogStash::PluginMixins::AwsConfig::V2
     return opts
   end
 
+  def symbolized_settings
+    @symbolized_settings ||= symbolize_keys_and_cast_true_false(@additional_settings)
+  end
+
   private
 
   def aws_credentials
@@ -70,4 +74,20 @@ module LogStash::PluginMixins::AwsConfig::V2
         :role_session_name => @role_session_name
     )
   end
+
+  def symbolize_keys_and_cast_true_false(hash)
+    case hash
+    when Hash
+      symbolized = {}
+      hash.each { |key, value| symbolized[key.to_sym] = symbolize_keys_and_cast_true_false(value) }
+      symbolized
+    when 'true'
+      true
+    when 'false'
+      false
+    else
+      hash
+    end
+  end
+
 end

--- a/logstash-mixin-aws.gemspec
+++ b/logstash-mixin-aws.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-mixin-aws'
-  s.version         = '5.0.0'
+  s.version         = '5.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "AWS mixins to provide a unified interface for Amazon Webservice"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?
Moves symbolization code of `additional_settings` used by S3 input and SQS input into common place.
If the including plugin defines the config attribute `addistiona_settings` then the method `aws_options_hash` symbolize the `additional_settings` map, merging the outcome into the options available to the plugin itself. 

## Why is it important/What is the impact to the user?
As a developer it reduces the need to copy and paste code to provide `additional_settings` config.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] build locally, install on a LS instance and check the the existing SQS input (the same is valid for S3 input) doesn't break when including this mixin.

## How to test this PR locally
- build the gem `gem build`
- install on a local LS instance: `bin/ruby -S gem install /hpath_to/logstash-mixin-aws/logstash-mixin-aws-5.1.0.gem`
- remove (if present) the SQS input and reinstall so that the `Gemfile.lock` takes the update to 
```
logstash-mixin-aws (5.1.0)
```
- run a LS pipeline with SQS input and check it still works.

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->



